### PR TITLE
Remove deprecated TransformVariables functions

### DIFF
--- a/src/estimation/estimation.jl
+++ b/src/estimation/estimation.jl
@@ -1122,8 +1122,6 @@ function transform_variance(T::TransformVariables.TransformTuple, m, var)
 end
 
 transform_std(::TransformVariables.Identity, x, std) = std
-transform_std(::TransformVariables.ShiftedExp{true, Int64}, x, std) = exp.(x).*std
-transform_std(::TransformVariables.ScaledShiftedLogistic{<:Real}, x, std) = logistic.(x).*(1-logistic.(x)).*std
 
 # inverse transformation of standard errors using delta approach
 function inverse_transform_std(T::TransformVariables.TransformTuple, x, std)
@@ -1146,8 +1144,6 @@ function inverse_transform_variance(T::TransformVariables.TransformTuple, m, var
 end
 
 inverse_transform_std(::TransformVariables.Identity, x, std) = std
-inverse_transform_std(::TransformVariables.ShiftedExp{true, Int64}, x, std) = std./x
-inverse_transform_std(::TransformVariables.ScaledShiftedLogistic{<:Real}, x, std) = std./((1 .- x).*x)
 
 function find(names::Vector, s)
     for (i, n) in enumerate(names)


### PR DESCRIPTION
Two functions were defined, but never used, for a struct that was removed from the original TransformVariables.jl library. This didn't allow me to compile Dynare locally.

The removal [happened recently](https://github.com/tpapp/TransformVariables.jl/commit/13034d4c7d287240097bcd15966779093c186a78) and alternatives were dicussed [here](https://github.com/tpapp/TransformVariables.jl/pull/128). 
Instead of
`TransformVariables.ShiftedExp{true,Float64}(0.0)`
It is instructed to use
`TVShift(0.0) ∘ TVExp()`